### PR TITLE
Minor clean up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,8 @@ jobs:
         with:
           python-version: '3.10'
       # TODO: We should find a way to use the cffi called out in the pyproject.toml
-      - name: Install cffi and maturin
-        run: pip install cffi==1.15.1 maturin==0.12.9
+      - name: Install cffi
+        run: pip install cffi==1.15.1
       - name: Build
         run: cargo xtask build --release
       - uses: actions/upload-artifact@v3
@@ -74,8 +74,8 @@ jobs:
         with:
           python-version: '3.10'
       # TODO: We should find a way to use the cffi called out in the pyproject.toml
-      - name: Install cffi and maturin
-        run: pip install cffi==1.15.1 maturin==0.12.9
+      - name: Install cffi
+        run: pip install cffi==1.15.1
       - name: Build
         run: cargo xtask build --asan
       - uses: actions/upload-artifact@v3

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -61,7 +61,7 @@ pub fn free_scan(_item: FfiResult<Scan>) {}
 #[ffi_export]
 pub fn start_scan(
     builder: &Builder,
-    callback: unsafe extern "C" fn(StreamItem<FfiResult<Report>>),
+    callback: extern "C" fn(StreamItem<FfiResult<Report>>),
 ) -> FfiResult<Scan> {
     if builder.tracing {
         setup_tracing();
@@ -84,10 +84,8 @@ pub fn start_scan(
         {
             Ok(stream) => stream,
             Err(e) => {
-                unsafe {
-                    callback(StreamItem::next(e.into()));
-                    callback(StreamItem::done());
-                }
+                callback(StreamItem::next(e.into()));
+                callback(StreamItem::done());
                 return;
             }
         };
@@ -98,11 +96,9 @@ pub fn start_scan(
                 contents: Some(repr_c::Box::new(report)),
             });
 
-            unsafe {
-                callback(ret);
-            }
+            callback(ret);
         }
-        unsafe { callback(StreamItem::done()) }
+        callback(StreamItem::done())
     });
     FfiResult {
         status_code: StatusCodes::Ok,


### PR DESCRIPTION
The call back into start_scan doesn't need to be unsafe.  Removing this cleaned up more unsafe blocks.

Next the maturin install in CI was unneeded.